### PR TITLE
chore(devenv): sync bootstrap files from openRin PR 433

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,10 @@ S3_FORCE_PATH_STYLE=false
 # database: 使用数据库存储缓存（推荐，开箱即用）
 CACHE_STORAGE_MODE=database
 
+# 路由实现选择（默认：hono）
+# 可选: hono | legacy
+ROUTER_IMPL=hono
+
 # Webhook 通知地址（可选）
 WEBHOOK_URL=
 

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use devenv

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/cachix/devenv/main/docs/src/devenv.schema.json
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+
+  devenv:
+    url: github:cachix/devenv?dir=src/modules


### PR DESCRIPTION
## Summary
- add `.envrc` with `use devenv`
- add `devenv.yaml` (devenv inputs schema/config)
- add `ROUTER_IMPL=hono` docs knob to `.env.example`

## Why
`openRin/Rin#433` was opened against the wrong repository and closed unmerged.
This PR ports the missing pieces into `Bad3r/Rin`.

## Validation
- `nix --option allow-import-from-derivation true develop -c pre-commit run --all-files`
- `nix --option allow-import-from-derivation true develop -c pre-commit run --all-files --hook-stage pre-push`
