### PR TITLE
chore(gitignore): ignore local plan docs and non-server Wrangler type outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dist-ssr
 
 # Local generated devenv artifacts
 /.devenv.flake.nix
+/devenv.lock
 
 # Wrangler-generated types:
 # keep server/worker-configuration.d.ts as source-of-truth,


### PR DESCRIPTION
## Summary
- ignore local generated `worker-configuration.d.ts` files globally
- explicitly keep `server/worker-configuration.d.ts` tracked as the repository source-of-truth
- ignore local planning scratch markdown files matching `*plan*.md`
- keep `flake.lock` as the single Nix pin source in this PR scope (no `devenv.lock` tracked)

## Why
- avoids accidental root/subdir wrangler type artifact noise while preserving the tracked server type definition
- keeps local planning files out of commits
- avoids dual lockfile pin drift between `flake.lock` and `devenv.lock`

## Validation
- `bun run check`
- `nix develop --accept-flake-config -c pre-commit run --all-files --hook-stage pre-push`
- pre-push hooks on `git push` passed (`actionlint`, `biome check`, `yamllint`)
