### PR TITLE
ci(deploy): auto-resolve manual artifact source by release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -336,7 +336,7 @@ jobs:
           fi
 
       - name: Log resolved artifact provenance
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ success() && github.event_name == 'workflow_dispatch' }}
         env:
           ARTIFACT_SOURCE: ${{ steps.dispatch_artifact.outputs.artifact_source }}
           ARTIFACT_URL: ${{ steps.dispatch_artifact.outputs.artifact_url }}
@@ -378,9 +378,9 @@ jobs:
 
               REF=$(cat ./artifacts/build-meta/ref 2>/dev/null || echo "unknown")
               if [[ "$REF" == "unknown" && ( "${DISPATCH_ARTIFACT_SOURCE:-}" == "latest" || "${DISPATCH_ARTIFACT_SOURCE:-}" == "version" ) ]]; then
-                if [[ "${DISPATCH_RELEASE_TARGET:-}" == "main" || "${DISPATCH_RELEASE_TARGET:-}" == "refs/heads/main" ]]; then
+                if [[ "${DISPATCH_RELEASE_TARGET:-}" == "main" ]]; then
                   REF="refs/heads/main"
-                elif [[ "${DISPATCH_RELEASE_TARGET:-}" == "dev" || "${DISPATCH_RELEASE_TARGET:-}" == "refs/heads/dev" ]]; then
+                elif [[ "${DISPATCH_RELEASE_TARGET:-}" == "dev" ]]; then
                   REF="refs/heads/dev"
                 fi
               fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,9 @@ jobs:
           set -euo pipefail
           mkdir -p ./build-meta
 
+          # Intentional policy: only releases whose tagged commit is already reachable
+          # from origin/main or origin/dev are marked production-eligible. Other tag
+          # lineages keep REF=unknown and are blocked by deploy production gating.
           REF="unknown"
           if git show-ref --verify --quiet refs/remotes/origin/main && git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
             REF="refs/heads/main"


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` artifact source selection (`latest`, `version`, `url`) in deploy workflow
- auto-resolve Cloudflare build artifact from GitHub Releases for `latest` and `version`
- keep backward-compatible manual URL mode and harden artifact download/extraction checks

## Details
- resolves release assets using `actions/github-script` with stable-only release policy
- supports explicit version tags (`1.2.3` or `v1.2.3`)
- validates artifact presence and errors clearly when missing
- keeps existing non-manual deploy paths (`workflow_run`, PR label flow) unchanged

## Validation
- `devenv shell --nix-option allow-import-from-derivation true git commit ...`
  - pre-commit hook: `treefmt check` passed
- `devenv shell --nix-option allow-import-from-derivation true git push ...`
  - pre-push hooks passed: `actionlint`, `biome check`, `yamllint`
