### PR TITLE
fix(app): harden search privacy, pagination, and about bootstrap

### DIFF
--- a/client/src/api/__tests__/client.test.ts
+++ b/client/src/api/__tests__/client.test.ts
@@ -195,6 +195,49 @@ describe('API Client', () => {
     })
   })
 
+  describe('Search API', () => {
+    it('should send page and limit query parameters', async () => {
+      const mockResponse = {
+        size: 2,
+        data: [{ id: 1, title: 'Result 1', content: 'Result Content 1' }],
+        hasNext: true,
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['content-type', 'application/json']]),
+        json: async () => mockResponse,
+      })
+
+      const result = await api.search.search('test keyword', { page: 2, limit: 1 })
+
+      expect(result.data).toEqual(mockResponse)
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost/api/search/test%20keyword?page=2&limit=1',
+        expect.any(Object)
+      )
+    })
+
+    it('should call search endpoint without query when pagination options are omitted', async () => {
+      const mockResponse = {
+        size: 1,
+        data: [{ id: 1, title: 'Only Result', content: 'Result Content' }],
+        hasNext: false,
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Map([['content-type', 'application/json']]),
+        json: async () => mockResponse,
+      })
+
+      const result = await api.search.search('test')
+
+      expect(result.data).toEqual(mockResponse)
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost/api/search/test', expect.any(Object))
+    })
+  })
+
   describe('User API', () => {
     it('should fetch user profile', async () => {
       const mockResponse = {

--- a/client/src/api/__tests__/client.test.ts
+++ b/client/src/api/__tests__/client.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createClient } from '../client'
 
-const api = createClient('http://localhost')
+const api = createClient('https://example.test')
 
 // Mock fetch globally
 const mockFetch = vi.fn()
@@ -62,7 +62,7 @@ describe('API Client', () => {
       const result = await api.feed.get(1)
 
       expect(result.data).toEqual(mockResponse)
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost/api/feed/1', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://example.test/api/feed/1', expect.any(Object))
     })
 
     it('should create feed', async () => {
@@ -85,7 +85,7 @@ describe('API Client', () => {
 
       expect(result.data).toEqual(mockResponse)
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost/api/feed',
+        'https://example.test/api/feed',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(feedData),
@@ -115,7 +115,7 @@ describe('API Client', () => {
       const result = await api.feed.adjacent(2)
 
       expect(result.data).toEqual(mockResponse)
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost/api/feed/adjacent/2', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://example.test/api/feed/adjacent/2', expect.any(Object))
     })
   })
 
@@ -149,7 +149,7 @@ describe('API Client', () => {
       const result = await api.tag.get('tag1')
 
       expect(result.data).toEqual(mockResponse)
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost/api/tag/tag1', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://example.test/api/tag/tag1', expect.any(Object))
     })
   })
 
@@ -169,7 +169,7 @@ describe('API Client', () => {
       const result = await api.comment.list(1)
 
       expect(result.data).toEqual(mockResponse)
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost/api/comment/1', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://example.test/api/comment/1', expect.any(Object))
     })
 
     it('should create comment', async () => {
@@ -186,7 +186,7 @@ describe('API Client', () => {
 
       expect(result.data).toEqual(mockResponse)
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost/api/comment/1',
+        'https://example.test/api/comment/1',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(commentData),
@@ -213,7 +213,7 @@ describe('API Client', () => {
 
       expect(result.data).toEqual(mockResponse)
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost/api/search/test%20keyword?page=2&limit=1',
+        'https://example.test/api/search/test%20keyword?page=2&limit=1',
         expect.any(Object)
       )
     })
@@ -234,7 +234,7 @@ describe('API Client', () => {
       const result = await api.search.search('test')
 
       expect(result.data).toEqual(mockResponse)
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost/api/search/test', expect.any(Object))
+      expect(mockFetch).toHaveBeenCalledWith('https://example.test/api/search/test', expect.any(Object))
     })
   })
 
@@ -272,7 +272,7 @@ describe('API Client', () => {
 
       expect(result.data).toEqual(mockResponse)
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost/api/user/profile',
+        'https://example.test/api/user/profile',
         expect.objectContaining({
           method: 'PUT',
           body: JSON.stringify(profileData),
@@ -300,7 +300,7 @@ describe('API Client', () => {
 
       expect(result.data).toEqual(mockResponse)
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost/api/auth/login',
+        'https://example.test/api/auth/login',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(loginData),

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -205,8 +205,8 @@ class FeedAPI {
     type?: 'draft' | 'unlisted' | 'normal'
   }): Promise<ApiResponse<FeedListResponse>> {
     const searchParams = new URLSearchParams()
-    if (params?.page) searchParams.set('page', params.page.toString())
-    if (params?.limit) searchParams.set('limit', params.limit.toString())
+    if (params?.page !== undefined) searchParams.set('page', params.page.toString())
+    if (params?.limit !== undefined) searchParams.set('limit', params.limit.toString())
     if (params?.type) searchParams.set('type', params.type)
 
     const query = searchParams.toString()
@@ -351,8 +351,8 @@ class MomentsAPI {
   // GET /api/moments
   async list(params?: { page?: number; limit?: number }): Promise<ApiResponse<{ data: Moment[]; hasNext: boolean }>> {
     const searchParams = new URLSearchParams()
-    if (params?.page) searchParams.set('page', params.page.toString())
-    if (params?.limit) searchParams.set('limit', params.limit.toString())
+    if (params?.page !== undefined) searchParams.set('page', params.page.toString())
+    if (params?.limit !== undefined) searchParams.set('limit', params.limit.toString())
 
     const query = searchParams.toString()
     return this.http.get<{ data: Moment[]; hasNext: boolean }>(`/api/moments${query ? `?${query}` : ''}`)

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -466,8 +466,19 @@ class SearchAPI {
   constructor(private http: HttpClient) {}
 
   // GET /api/search/:keyword
-  async search(keyword: string): Promise<ApiResponse<FeedListResponse>> {
-    return this.http.get<FeedListResponse>(`/api/search/${encodeURIComponent(keyword)}`)
+  async search(
+    keyword: string,
+    options?: {
+      page?: number
+      limit?: number
+    }
+  ): Promise<ApiResponse<FeedListResponse>> {
+    const searchParams = new URLSearchParams()
+    if (options?.page !== undefined) searchParams.set('page', options.page.toString())
+    if (options?.limit !== undefined) searchParams.set('limit', options.limit.toString())
+    const query = searchParams.toString()
+
+    return this.http.get<FeedListResponse>(`/api/search/${encodeURIComponent(keyword)}${query ? `?${query}` : ''}`)
   }
 }
 

--- a/client/src/page/__tests__/search.test.tsx
+++ b/client/src/page/__tests__/search.test.tsx
@@ -1,0 +1,69 @@
+import { render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { SearchPage } from '../search'
+
+const { searchSpy } = vi.hoisted(() => ({
+  searchSpy: vi.fn(async () => ({
+    data: {
+      size: 0,
+      data: [],
+      hasNext: false,
+    },
+  })),
+}))
+
+vi.mock('../../main', () => ({
+  client: {
+    search: {
+      search: searchSpy,
+    },
+  },
+}))
+
+vi.mock('../../hooks/useSiteConfig', () => ({
+  useSiteConfig: () => ({
+    name: 'Test Site',
+    avatar: '/avatar.png',
+    pageSize: 5,
+  }),
+}))
+
+vi.mock('../../components/helmet', () => ({
+  Helmet: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../../components/feed_card', () => ({
+  FeedCard: () => null,
+}))
+
+vi.mock('../../components/loading', () => ({
+  Waiting: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('wouter', async importOriginal => {
+  const original = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...original,
+    useSearch: () => '?page=2&limit=1',
+    Link: ({ children, href }: { children?: ReactNode; href: string }) => <a href={href}>{children}</a>,
+  }
+})
+
+describe('SearchPage', () => {
+  it('passes page and limit from URL query to search API', async () => {
+    searchSpy.mockClear()
+
+    render(<SearchPage keyword='query-keyword' />)
+
+    await waitFor(() => {
+      expect(searchSpy).toHaveBeenCalledWith('query-keyword', { page: 2, limit: 1 })
+    })
+  })
+})

--- a/client/src/page/search.tsx
+++ b/client/src/page/search.tsx
@@ -27,7 +27,7 @@ export function SearchPage({ keyword }: { keyword: string }) {
     if (ref.current === key || !keyword) return
     ref.current = key
     setStatus('loading')
-    client.search.search(keyword).then(({ data }) => {
+    client.search.search(keyword, { page, limit }).then(({ data }) => {
       if (ref.current !== key) return
       if (data) {
         setFeeds(data)

--- a/scripts/db-migrate-local.ts
+++ b/scripts/db-migrate-local.ts
@@ -7,6 +7,38 @@ import { isKnownTopColumnCatchUpCase } from './migration-utils'
 const DB_NAME = 'rin'
 const SQL_DIR = path.join(__dirname, '..', 'server', 'sql')
 
+const ABOUT_SEED_SQL = `INSERT INTO feeds (alias, title, summary, content, listed, draft, uid, top, created_at, updated_at)
+SELECT
+  'about',
+  'About',
+  'Welcome to Rin. Update this page from the Writing panel.',
+  'Welcome to Rin. Update this page from the Writing panel.',
+  1,
+  0,
+  users.id,
+  0,
+  unixepoch(),
+  unixepoch()
+FROM users
+WHERE users.permission = 1
+  AND NOT EXISTS (SELECT 1 FROM feeds WHERE alias = 'about')
+LIMIT 1;`
+
+async function ensureAboutSeed(typ: string, dbName: string): Promise<void> {
+  const { exitCode, stdout, stderr } = await $`bunx wrangler d1 execute ${dbName} --${typ} --command ${ABOUT_SEED_SQL}`
+    .quiet()
+    .nothrow()
+
+  if (exitCode !== 0) {
+    const output = `${stdout.toString()}\n${stderr.toString()}`.trim()
+    console.error('Failed to seed default About page')
+    if (output) {
+      console.error(output)
+    }
+    process.exit(1)
+  }
+}
+
 // Change to the server/sql directory
 process.chdir(SQL_DIR)
 const typ = 'local'
@@ -62,6 +94,7 @@ if (sqlFiles.length === 0) {
 }
 
 await fixTopField(typ, DB_NAME, isInfoExistResult)
+await ensureAboutSeed(typ, DB_NAME)
 
 // Back to the root directory (optional, as the script ends)
 process.chdir(__dirname)

--- a/server/sql/0010.sql
+++ b/server/sql/0010.sql
@@ -1,0 +1,19 @@
+-- Seed default About page when an admin user exists and no About alias is present.
+INSERT INTO `feeds` (`alias`, `title`, `summary`, `content`, `listed`, `draft`, `uid`, `top`, `created_at`, `updated_at`)
+SELECT
+  'about',
+  'About',
+  'Welcome to Rin. Update this page from the Writing panel.',
+  'Welcome to Rin. Update this page from the Writing panel.',
+  1,
+  0,
+  `users`.`id`,
+  0,
+  unixepoch(),
+  unixepoch()
+FROM `users`
+WHERE `users`.`permission` = 1
+  AND NOT EXISTS (SELECT 1 FROM `feeds` WHERE `alias` = 'about')
+LIMIT 1;
+--> statement-breakpoint
+UPDATE `info` SET `value` = '10' WHERE `key` = 'migration_version';

--- a/server/sql/0011.sql
+++ b/server/sql/0011.sql
@@ -1,0 +1,4 @@
+-- Ensure only one About alias row can exist.
+CREATE UNIQUE INDEX IF NOT EXISTS `feeds_alias_about_unique` ON `feeds` (`alias`) WHERE `alias` = 'about';
+--> statement-breakpoint
+UPDATE `info` SET `value` = '11' WHERE `key` = 'migration_version';

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -6,6 +6,8 @@ const updated_at = integer('updated_at', { mode: 'timestamp' }).default(sql`(uni
 
 export const feeds = sqliteTable('feeds', {
   id: integer('id').primaryKey(),
+  // NOTE: "about" alias uniqueness is enforced by a partial unique index in server/sql/0011.sql.
+  // Drizzle table definitions cannot express this partial index; keep migration and schema in sync.
   alias: text('alias'),
   title: text('title'),
   summary: text('summary').default('').notNull(),

--- a/server/src/services/__tests__/feed.test.ts
+++ b/server/src/services/__tests__/feed.test.ts
@@ -18,6 +18,7 @@ describe('FeedService', () => {
     db = mockDB.db
     sqlite = mockDB.sqlite
     env = createMockEnv()
+    const cacheStore = new Map<string, unknown>()
 
     // Setup app with mock db
     app = createBaseApp(env)
@@ -27,12 +28,34 @@ describe('FeedService', () => {
       verify: async (token: string) => (token.startsWith('mock_token_') ? { id: 1 } : null),
     })
     app.state('cache', {
-      get: async () => undefined,
-      set: async () => {},
-      delete: async () => {},
-      deletePrefix: async () => {},
-      getOrSet: async (_key: string, fn: Function) => fn(),
-      getOrDefault: async (_key: string, defaultValue: any) => defaultValue,
+      get: async (key: string) => cacheStore.get(key),
+      set: async (key: string, value: unknown) => {
+        cacheStore.set(key, value)
+      },
+      delete: async (key: string) => {
+        cacheStore.delete(key)
+      },
+      deletePrefix: async (prefix: string) => {
+        for (const key of cacheStore.keys()) {
+          if (key.startsWith(prefix)) {
+            cacheStore.delete(key)
+          }
+        }
+      },
+      getOrSet: async (key: string, fn: Function) => {
+        if (cacheStore.has(key)) {
+          return cacheStore.get(key)
+        }
+        const value = await fn()
+        cacheStore.set(key, value)
+        return value
+      },
+      getOrDefault: async (key: string, defaultValue: unknown) => {
+        if (cacheStore.has(key)) {
+          return cacheStore.get(key)
+        }
+        return defaultValue
+      },
     })
     app.state('clientConfig', {
       getOrDefault: async (_key: string, defaultValue: any) => defaultValue,
@@ -166,6 +189,194 @@ describe('FeedService', () => {
 
       expect(result.error).toBeDefined()
       expect(result.error?.status).toBe(404)
+    })
+  })
+
+  describe('GET /search/:keyword - Search feeds', () => {
+    it('should exclude draft and unlisted feeds for non-admin users', async () => {
+      const keyword = 'search-public-filter'
+      await api.feed.create(
+        {
+          title: `${keyword}-public`,
+          content: `content ${keyword} public`,
+          listed: true,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+      await api.feed.create(
+        {
+          title: `${keyword}-draft`,
+          content: `content ${keyword} draft`,
+          listed: true,
+          draft: true,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+      await api.feed.create(
+        {
+          title: `${keyword}-unlisted`,
+          content: `content ${keyword} unlisted`,
+          listed: false,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+
+      const result = await api.search.search(keyword)
+
+      expect(result.error).toBeUndefined()
+      expect(result.data?.size).toBe(1)
+      expect(result.data?.data).toHaveLength(1)
+      expect(result.data?.data[0]?.title).toBe(`${keyword}-public`)
+    })
+
+    it('should include draft and unlisted feeds for admin users', async () => {
+      const keyword = 'search-admin-all'
+      await api.feed.create(
+        {
+          title: `${keyword}-public`,
+          content: `content ${keyword} public`,
+          listed: true,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+      await api.feed.create(
+        {
+          title: `${keyword}-draft`,
+          content: `content ${keyword} draft`,
+          listed: true,
+          draft: true,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+      await api.feed.create(
+        {
+          title: `${keyword}-unlisted`,
+          content: `content ${keyword} unlisted`,
+          listed: false,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+
+      const result = await api.search.search(keyword, undefined, { token: 'mock_token_1' })
+
+      expect(result.error).toBeUndefined()
+      expect(result.data?.size).toBe(3)
+      expect(result.data?.data).toHaveLength(3)
+    })
+
+    it('should not leak admin search cache entries to non-admin users', async () => {
+      const keyword = 'search-cache-admin-first'
+      await api.feed.create(
+        {
+          title: `${keyword}-public`,
+          content: `content ${keyword} public`,
+          listed: true,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+      await api.feed.create(
+        {
+          title: `${keyword}-draft`,
+          content: `content ${keyword} draft`,
+          listed: true,
+          draft: true,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+
+      const adminResult = await api.search.search(keyword, undefined, { token: 'mock_token_1' })
+      expect(adminResult.error).toBeUndefined()
+      expect(adminResult.data?.size).toBe(2)
+
+      const publicResult = await api.search.search(keyword)
+
+      expect(publicResult.error).toBeUndefined()
+      expect(publicResult.data?.size).toBe(1)
+      expect(publicResult.data?.data).toHaveLength(1)
+      expect(publicResult.data?.data[0]?.title).toBe(`${keyword}-public`)
+    })
+
+    it('should keep admin results complete after a public search caches first', async () => {
+      const keyword = 'search-cache-public-first'
+      await api.feed.create(
+        {
+          title: `${keyword}-public`,
+          content: `content ${keyword} public`,
+          listed: true,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+      await api.feed.create(
+        {
+          title: `${keyword}-draft`,
+          content: `content ${keyword} draft`,
+          listed: true,
+          draft: true,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+
+      const publicResult = await api.search.search(keyword)
+      expect(publicResult.error).toBeUndefined()
+      expect(publicResult.data?.size).toBe(1)
+
+      const adminResult = await api.search.search(keyword, undefined, { token: 'mock_token_1' })
+
+      expect(adminResult.error).toBeUndefined()
+      expect(adminResult.data?.size).toBe(2)
+      expect(adminResult.data?.data).toHaveLength(2)
+    })
+
+    it('should honor page and limit query parameters', async () => {
+      const keyword = 'search-pagination'
+      await api.feed.create(
+        {
+          title: `${keyword}-a`,
+          content: `content ${keyword} a`,
+          listed: true,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+      await api.feed.create(
+        {
+          title: `${keyword}-b`,
+          content: `content ${keyword} b`,
+          listed: true,
+          draft: false,
+          tags: [],
+        },
+        { token: 'mock_token_1' }
+      )
+
+      const page1 = await api.search.search(keyword, { page: 1, limit: 1 })
+      expect(page1.error).toBeUndefined()
+      expect(page1.data?.size).toBe(2)
+      expect(page1.data?.data).toHaveLength(1)
+      expect(page1.data?.hasNext).toBe(true)
+
+      const page2 = await api.search.search(keyword, { page: 2, limit: 1 })
+      expect(page2.error).toBeUndefined()
+      expect(page2.data?.size).toBe(2)
+      expect(page2.data?.data).toHaveLength(1)
+      expect(page2.data?.hasNext).toBe(false)
     })
   })
 

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -98,9 +98,10 @@ export function PasswordAuthService(router: Router): void {
         }
 
         if ((aboutSeedResult.meta?.changes ?? 0) > 0) {
+          // Remove direct about cache entry first, then persist removals via prefix deletes.
+          await cache.delete('feed_about', false)
           await cache.deletePrefix('feeds_')
           await cache.deletePrefix('search_')
-          await cache.delete('feed_about')
         }
 
         // Generate JWT token

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm'
 import type { Router } from '../core/router'
 import type { Context } from '../core/types'
-import { users } from '../db/schema'
+import { feeds, users } from '../db/schema'
 import { BadRequestError, ForbiddenError, InternalServerError } from '../errors'
 
 // Hash password using SHA-256
@@ -82,6 +82,23 @@ export function PasswordAuthService(router: Router): void {
 
         if (!user) {
           throw new InternalServerError('Failed to get admin user')
+        }
+
+        const aboutPage = await db.query.feeds.findFirst({
+          where: eq(feeds.alias, 'about'),
+          columns: { id: true },
+        })
+        if (!aboutPage) {
+          const placeholderContent = 'Welcome to Rin. Update this page from the Writing panel.'
+          await db.insert(feeds).values({
+            alias: 'about',
+            title: 'About',
+            summary: placeholderContent,
+            content: placeholderContent,
+            listed: 1,
+            draft: 0,
+            uid: user.id,
+          })
         }
 
         // Generate JWT token

--- a/server/src/services/feed.ts
+++ b/server/src/services/feed.ts
@@ -820,7 +820,8 @@ export function FeedService(router: Router): void {
         success++
       }
 
-      cache.deletePrefix('feeds_')
+      await cache.deletePrefix('feeds_')
+      await cache.deletePrefix('search_')
       return { success, skipped, skippedList }
     },
     wpImportSchema

--- a/server/tests/integration/api.test.ts
+++ b/server/tests/integration/api.test.ts
@@ -24,6 +24,7 @@ describe('Integration Tests - API Flow', () => {
     app.state('cache', {
       get: async () => undefined,
       set: async () => {},
+      delete: async () => {},
       deletePrefix: async () => {},
       getOrSet: async (_key: string, fn: Function) => fn(),
       getOrDefault: async (_key: string, defaultValue: any) => defaultValue,

--- a/server/tests/test-api-client.ts
+++ b/server/tests/test-api-client.ts
@@ -181,8 +181,8 @@ export class TestAPIClient {
       options?: TestAPIOptions
     ): Promise<ApiResponse<FeedListResponse>> => {
       const searchParams = new URLSearchParams()
-      if (params?.page) searchParams.set('page', params.page.toString())
-      if (params?.limit) searchParams.set('limit', params.limit.toString())
+      if (params?.page !== undefined) searchParams.set('page', params.page.toString())
+      if (params?.limit !== undefined) searchParams.set('limit', params.limit.toString())
       if (params?.type) searchParams.set('type', params.type)
 
       const query = searchParams.toString()
@@ -306,8 +306,8 @@ export class TestAPIClient {
       options?: TestAPIOptions
     ): Promise<ApiResponse<{ data: Moment[]; hasNext: boolean }>> => {
       const searchParams = new URLSearchParams()
-      if (params?.page) searchParams.set('page', params.page.toString())
-      if (params?.limit) searchParams.set('limit', params.limit.toString())
+      if (params?.page !== undefined) searchParams.set('page', params.page.toString())
+      if (params?.limit !== undefined) searchParams.set('limit', params.limit.toString())
 
       const query = searchParams.toString()
       return this.get<{ data: Moment[]; hasNext: boolean }>(`/moments${query ? `?${query}` : ''}`, options)
@@ -402,8 +402,8 @@ export class TestAPIClient {
       options?: TestAPIOptions
     ): Promise<ApiResponse<FeedListResponse>> => {
       const searchParams = new URLSearchParams()
-      if (params?.page) searchParams.set('page', params.page.toString())
-      if (params?.limit) searchParams.set('limit', params.limit.toString())
+      if (params?.page !== undefined) searchParams.set('page', params.page.toString())
+      if (params?.limit !== undefined) searchParams.set('limit', params.limit.toString())
       const query = searchParams.toString()
 
       return this.get<FeedListResponse>(`/search/${encodeURIComponent(keyword)}${query ? `?${query}` : ''}`, options)

--- a/server/tests/test-api-client.ts
+++ b/server/tests/test-api-client.ts
@@ -396,8 +396,17 @@ export class TestAPIClient {
 
   // Search API
   search = {
-    search: async (keyword: string, options?: TestAPIOptions): Promise<ApiResponse<FeedListResponse>> => {
-      return this.get<FeedListResponse>(`/search/${encodeURIComponent(keyword)}`, options)
+    search: async (
+      keyword: string,
+      params?: { page?: number; limit?: number },
+      options?: TestAPIOptions
+    ): Promise<ApiResponse<FeedListResponse>> => {
+      const searchParams = new URLSearchParams()
+      if (params?.page) searchParams.set('page', params.page.toString())
+      if (params?.limit) searchParams.set('limit', params.limit.toString())
+      const query = searchParams.toString()
+
+      return this.get<FeedListResponse>(`/search/${encodeURIComponent(keyword)}${query ? `?${query}` : ''}`, options)
     },
   }
 


### PR DESCRIPTION
## Summary
- harden server-side search visibility handling by separating cache keys for public and authenticated search results
- fix client search pagination by passing `page` and `limit` through `SearchAPI.search(...)` and the search page caller
- bootstrap the `about` page idempotently on admin login and add a local SQL migration seed for environments missing the page
- add regression tests for search visibility/cache behavior, search pagination request composition, and about-page seeding

## Validation
- `devenv shell --nix-option allow-import-from-derivation true -- bun run check`
- `devenv shell --nix-option allow-import-from-derivation true -- bun --filter './server' test src/services/__tests__/feed.test.ts src/services/__tests__/auth.test.ts`
- `devenv shell --nix-option allow-import-from-derivation true -- bun --filter './client' test src/page/__tests__/search.test.tsx src/api/__tests__/client.test.ts`
