### PR TITLE
fix(deploy): pass secret values to wrangler as bytes

### DIFF
--- a/scripts/deploy-cf.ts
+++ b/scripts/deploy-cf.ts
@@ -350,8 +350,9 @@ mode = ${toTomlString('smart')}
   async function putSecret(name: string, value?: string) {
     if (value) {
       console.log(`Put ${name}`)
+      // Bun >= 1.3 rejects a plain string for stdin (ERR_INVALID_ARG_TYPE); pass bytes.
       const process = Bun.spawn(['bunx', 'wrangler', 'secret', 'put', name], {
-        stdin: value,
+        stdin: Buffer.from(value),
         stdout: 'inherit',
         stderr: 'inherit',
       })


### PR DESCRIPTION
The first post-merge Deploy run (after PR #66) failed at putSecret: Bun 1.3 rejects a plain string for Bun.spawn stdin with ERR_INVALID_ARG_TYPE. Migrations had already applied cleanly (rin reached migration_version 13 with the 0011 duplicate-top catch-up firing as designed); only secret upload and the worker publish were left undone.

Buffer.from(value) is an accepted stdin type. Verified on Bun 1.3.9 locally: string stdin reproduces the exact CI error, Buffer round-trips through cat.

Validation: bun run check.